### PR TITLE
Socket 통신을 위한 Stomp 구현

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -54,6 +54,15 @@ object Versions {
         const val Master = "2.2.0"
         const val Compose = "1.0.0-alpha07"
     }
+
+    object Stomp{
+        const val Master = "1.6.6"
+    }
+
+    object Rx{
+        const val Java = "2.2.5"
+        const val Android = "2.1.0"
+    }
 }
 
 object Dependencies {
@@ -107,5 +116,14 @@ object Dependencies {
         "androidx.lifecycle:lifecycle-extensions:${Versions.Lifecycle.Master}",
         "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.Lifecycle.Master}",
         "androidx.lifecycle:lifecycle-viewmodel-compose:${Versions.Lifecycle.Compose}"
+    )
+
+    val stomp = listOf(
+        "com.github.NaikSoftware:StompProtocolAndroid:${Versions.Stomp.Master}"
+    )
+
+    val rx = listOf(
+        "io.reactivex.rxjava2:rxjava:${Versions.Rx.Java}",
+        "io.reactivex.rxjava2:rxandroid:${Versions.Rx.Android}"
     )
 }

--- a/data/src/main/kotlin/team/mobileb/opgg/data/api/RoomsApi.kt
+++ b/data/src/main/kotlin/team/mobileb/opgg/data/api/RoomsApi.kt
@@ -1,18 +1,15 @@
 package team.mobileb.opgg.data.api
 
 import retrofit2.Response
-import retrofit2.http.GET
-import retrofit2.http.Headers
-import retrofit2.http.POST
-import retrofit2.http.Path
-import retrofit2.http.Query
+import retrofit2.http.*
 import team.mobileb.opgg.data.model.CheckInfoResponse
 import team.mobileb.opgg.data.model.RoomInfoResponse
+import team.mobileb.opgg.data.model.UserInputData
 
 interface RoomsApi {
-    @Headers("Content-Type: application/hal+json", "Accept: application/hal+json")
+    @Headers("Content-Type: application/json", "Host: localhost:8080")
     @POST
-    suspend fun createRoom(@Query("userKey") userKey: String): Response<RoomInfoResponse>
+    suspend fun createRoom(@Body userInputData: UserInputData): Response<RoomInfoResponse>
 
     @GET("{userKey}")
     suspend fun retrieveRoom(@Path("userKey") userKey: String): Response<RoomInfoResponse>

--- a/data/src/main/kotlin/team/mobileb/opgg/data/api/UtilsApi.kt
+++ b/data/src/main/kotlin/team/mobileb/opgg/data/api/UtilsApi.kt
@@ -6,7 +6,7 @@ import retrofit2.http.Headers
 import team.mobileb.opgg.data.model.PositionInfoResponse
 
 interface UtilsApi {
-    @Headers("Content-Type: application/hal+json", "Accept: application/hal+json")
+    @Headers("Content-Type: application/json", "Host: localhost:8080")
     @GET("position")
     suspend fun retrievePosition(): Response<PositionInfoResponse>
 }

--- a/data/src/main/kotlin/team/mobileb/opgg/data/model/UserInputData.kt
+++ b/data/src/main/kotlin/team/mobileb/opgg/data/model/UserInputData.kt
@@ -1,0 +1,6 @@
+package team.mobileb.opgg.data.model
+
+data class UserInputData(
+    val userKey : String,
+    val inviteCode : String
+)

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -75,4 +75,6 @@ dependencies {
     Dependencies.hilt.forEach(::implementation)
     Dependencies.lifecycle.forEach(::implementation)
     Dependencies.compiler.forEach(::kapt)
+    Dependencies.stomp.forEach(::implementation)
+    Dependencies.rx.forEach(::implementation)
 }

--- a/presentation/src/main/kotlin/team/mobileb/opgg/activity/chat/ChatViewModel.kt
+++ b/presentation/src/main/kotlin/team/mobileb/opgg/activity/chat/ChatViewModel.kt
@@ -1,8 +1,37 @@
 package team.mobileb.opgg.activity.chat
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import org.json.JSONObject
+import ua.naiksoftware.stomp.Stomp
+import ua.naiksoftware.stomp.dto.StompHeader
 import javax.inject.Inject
 
 @HiltViewModel
-class ChatViewModel @Inject constructor() : ViewModel()
+class ChatViewModel @Inject constructor() : ViewModel() {
+
+    fun runStomp() {
+        val url = "ws://ec2-18-222-138-73.us-east-2.compute.amazonaws.com:3724/socket/websocket"
+        val stompClient = Stomp.over(Stomp.ConnectionProvider.OKHTTP, url)
+
+        stompClient.topic("/topic/message/test0912").subscribe { topicMessage ->
+            Log.i("message Recieve", topicMessage.payload)
+        }
+
+        val headerList = arrayListOf<StompHeader>()
+        headerList.add(StompHeader("inviteCode", "test0912")) // 방 생성시 입력한 inviteCode
+        headerList.add(StompHeader("username", "20")) // 방 생성시 입력한 userKey
+        headerList.add(StompHeader("positionType", "1"))
+        stompClient.connect(headerList)
+
+        val data = JSONObject()
+        data.put("userKey", "20") // 방 생성시 입력한 userKey
+        data.put("positionType", "1")
+        data.put("content", "test") // 메시지
+        data.put("messageType", "CHAT")
+        data.put("destRoomCode", "test0912") // 방 생성시 입력한 inviteCode
+
+        stompClient.send("/stream/chat/send", data.toString()).subscribe()
+    }
+}

--- a/presentation/src/main/kotlin/team/mobileb/opgg/di/module/ApiModule.kt
+++ b/presentation/src/main/kotlin/team/mobileb/opgg/di/module/ApiModule.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.KClass
 @Module
 @InstallIn(SingletonComponent::class)
 object ApiModule {
-    private const val BaseUrl = "http://18.189.220.120:8090/api/v1"
+    private const val BaseUrl = "http://ec2-18-222-138-73.us-east-2.compute.amazonaws.com:3724/api/v1"
 
     private fun getInterceptor(vararg interceptors: Interceptor): OkHttpClient {
         val builder = OkHttpClient.Builder()


### PR DESCRIPTION
- Stomp 라이브러리 추가
- API 수정

@jisungbin

프로젝트에서 작동하게하려면 코루틴이랑 Hilt부분을 건드려야해서 일단 코드만 적용해놨습니다

참고한 [Stomp 라이브러리](https://github.com/NaikSoftware/StompProtocolAndroid) 가 RxJava2 기반이라 Rx도 라이브러리에 추가했고
API 헤더부분 변경, 방 생성시 넘겨주는 값을 userKey와 inviteCode를 가지는 UserInputData로 변경했습니다
Stomp 구현한 코드는 ChatViewModel에 일단 써놨는데 join 클래스에서 소켓연결을 하고 ChatActivity에서 메시지를 발신, 수신하는 방식이 좋아보입니다

소켓 테스트 순서는 다음과 같습니다
1. 방 생성
2. userKey, inviteCode 전송
3. response 수신
4. socket 연결 
5. 메시지 발신 / 수신

이때 1번에서 입력한 userKey와 inviteCode로 socket에 연결해야 정상적으로 통신이 연결됩니다
제가 테스트한 userKey와 inviteCode는 코드에 적용해놨고 값 변경시에 코드도 바꿔주시면 됩니다

ChatViewModel 18번째줄에 
stompClient.topic("/topic/message/**test0912**").subscribe에서 test0912부분은 inviteCode이니 마찬가지로 값 변경시에 바꿔주시면 됩니다

정상적으로 socket에 연결됐을때 로그입니다

```
D/StompClient: Connect
I/zygote: Background concurrent copying GC freed 15923(881KB) AllocSpace objects, 1(20KB) LOS objects, 50% free, 1522KB/2MB, paused 1.827ms total 321.294ms
D/AbstractConnectionProvider: Emit lifecycle event: OPENED
D/AbstractConnectionProvider: Send STOMP message: CONNECT
    accept-version:1.1,1.2
    heart-beat:0,0
    inviteCode:test0912
    username:22
    positionType:1
    
    ��
D/StompClient: Publish open
D/AbstractConnectionProvider: Receive STOMP message: CONNECTED
    version:1.2
    heart-beat:0,0
    
    ��
D/AbstractConnectionProvider: Send STOMP message: SUBSCRIBE
    id:6f091454-4341-472b-95e9-0757ce53c9e6
    destination:/topic/message/test0912
    ack:auto
    
    ��
D/AbstractConnectionProvider: Send STOMP message: SEND
    destination:/stream/chat/send
    
    {"userKey":"22","positionType":"1","content":"test","messageType":"CHAT","destRoomCode":"test0912"}��
D/AbstractConnectionProvider: Receive STOMP message: MESSAGE
    destination:/topic/message/test0912
    content-type:application/json
    subscription:6f091454-4341-472b-95e9-0757ce53c9e6
    message-id:f1a46714-b799-afca-08e6-0d0e8503b6e2-10
    content-length:131
    
    {"userKey":"22","positionType":1,"positionName":"탑","content":"test","messageType":"CHAT","created_at_str":"2021-09-13 10:33:39"}��
D/HeartBeatTask: Aborted last check because server sent heart-beat on time ('1631496743360'). So well-behaved :)
I/message Recieve: {"userKey":"22","positionType":1,"positionName":"탑","content":"test","messageType":"CHAT","created_at_str":"2021-09-13 10:33:39"}
I/zygote: Do full code cache collection, code=244KB, data=189KB
I/zygote: After code cache collection, code=233KB, data=152KB
I/zygote: Do partial code cache collection, code=242KB, data=161KB
    After code cache collection, code=242KB, data=161KB
    Increasing code cache capacity to 1024KB

```
